### PR TITLE
Remove unnecessary line

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,6 @@ The differences are discussed later in this document.
 :java_version: 1.8
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/prereq_editor_jdk_buildtools.adoc[]
 
-====
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/how_to_complete_this_guide.adoc[]
 


### PR DESCRIPTION
Not 100% sure, but a leftover line from #87 might have caused some of the headings not to be shown properly. 

![image](https://user-images.githubusercontent.com/42799254/128347250-ecf388c7-ec26-48b6-b805-63b1053466df.png)

